### PR TITLE
update serverless serving to v1beta1 api

### DIFF
--- a/pre-requisites/operators-instance/serving.yaml
+++ b/pre-requisites/operators-instance/serving.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
     name: knative-serving


### PR DESCRIPTION
knative-serverless depreciated the v1alpha1 api for serving in 1.27.

For now if you deploy the v1alpha1 object it will automatically convert it to the v1beta1 object so this PR simply future proofs the demo for when v1alpha1 is eventually removed.

https://docs.openshift.com/container-platform/4.12/serverless/serverless-release-notes.html#serverless-deprecated-removed-features_serverless-release-notes