### PR TITLE
add edge termination to minio

### DIFF
--- a/openshift-data-science/routes/minio-route.yaml
+++ b/openshift-data-science/routes/minio-route.yaml
@@ -9,3 +9,6 @@ spec:
   to:
     kind: Service
     name: minio-service
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
The minio route currently returns an `Application is not available` error message when attempting to access it.  Adding the edge termination configuration resolves the issue and you are now able to access the minio UI.