### PR TITLE
add missing service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ oc apply -f ./pre-requisites/operators-instance/
 # Deploy the data science components
 oc apply -k ./openshift-data-science/
 #Create the initialization job that pull the dataset to minio bucket called *rhods*.
-oc apply -f ./lab/init/scripts/
-oc create -f ./lab/init/job.yaml
+oc apply -k ./lab/init/
 ```
 
 ### Do the lab

--- a/lab/init/job.yaml
+++ b/lab/init/job.yaml
@@ -1,6 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  name: lab-init
   generateName: lab-init-
   namespace: redhat-ods-applications
 spec:

--- a/lab/init/kustomization.yaml
+++ b/lab/init/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./sa/rbac.yaml
+  - ./sa/service-account.yaml
+  - ./scripts/init-scripts.yaml
+  - job.yaml

--- a/lab/init/sa/rbac.yaml
+++ b/lab/init/sa/rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: job-admin
+subjects:
+- kind: ServiceAccount
+  name: jobs
+  namespace: redhat-ods-applications
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/lab/init/sa/service-account.yaml
+++ b/lab/init/sa/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jobs
+  namespace: redhat-ods-applications


### PR DESCRIPTION
The job to init the data in minio is missing 

I duplicated the SA/RBAC from the reset code to allow the init job to run and setup a kustomization file so that all of the init resources can be applied in a single command.